### PR TITLE
Use correct BindableProperty for InfiniteScrollBehavior.ItemsSource

### DIFF
--- a/InfiniteScrolling/InfiniteScrollBehavior.cs
+++ b/InfiniteScrolling/InfiniteScrollBehavior.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Extended
 			private set => SetValue(IsLoadingMoreProperty, value);
 		}
 
-		private IEnumerable ItemsSource => (IEnumerable)GetValue(IsLoadingMoreProperty);
+		private IEnumerable ItemsSource => (IEnumerable)GetValue(ItemsSourceProperty);
 
 		protected override void OnAttachedTo(ListView bindable)
 		{


### PR DESCRIPTION
Feel free to ignore this.  It doesn't look like this property is ever actually accessed, but that may change in future.